### PR TITLE
Release v0.2.5

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,20 @@
 History
 =======
 
+v0.2.3 (September 13th, 2016)
+-----------------------------
+
+This is a patch release of outrigger, with non-breaking changes from the
+previous one.
+
+
+Bug fixes
+~~~~~~~~~
+
+- Subfolders get copied when installing
+- Add test for checking that ``outrigger -h`` command works
+
+
 v0.2.2 (September 12th, 2016)
 -----------------------------
 

--- a/docs/releases/checklist.md
+++ b/docs/releases/checklist.md
@@ -11,7 +11,7 @@ git tag -a v0.2.1 -m "v0.2.1 - Release *with* requirements.txt"
 git push origin v0.2.1
 ```
 
-- [ ] 6. If you messed up and made the tag too early and later made changes that should be added to the tag, remove the remote tag and force re-add the local tag:
+- [ ] 6. (If you messed up) and made the tag too early and later made changes that should be added to the tag, remove the remote tag and force re-add the local tag:
 
 ```
 git push origin :refs/tags/v0.2.1
@@ -26,7 +26,7 @@ python setup.py register -r pypitest
 python setup.py sdist upload -r pypitest
 ```
 
-- [ ] 8. If there's an error in either the `HISTORY.rst` or `README.rst` file, you will get an error. To narrow down this error, look for the corresponding line in `outrigger.egg-info`. It won't be exactly the same line because of the header but it will be closer since `PKG-INFO` concatenates your `README.rst` and `HISTORY.rst` files.
+- [ ] 8. (If there's an error) in either the `HISTORY.rst` or `README.rst` file, you will get an error. To narrow down this error, look for the corresponding line in `outrigger.egg-info`. It won't be exactly the same line because of the header but it will be closer since `PKG-INFO` concatenates your `README.rst` and `HISTORY.rst` files.
 
 ```
 warning: unexpected indent on line 615 blah blah I'm pypi RST and I'm way too strict
@@ -70,7 +70,7 @@ python setup.py register -r pypi
 python setup.py sdist upload -r pypi
 ```
 
-- [ ] 14. Upload to Anaconda.org:
+- [ ] 14. (Doesn't really work yet) Upload to Anaconda.org:
 
 ```
 anaconda login

--- a/outrigger/__init__.py
+++ b/outrigger/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = 'Olga Botvinnik'
 __email__ = 'olga.botvinnik@gmail.com'
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 
 __all__ = ['psi', 'region', 'util', 'io', 'validate', 'index']

--- a/outrigger/commandline.py
+++ b/outrigger/commandline.py
@@ -227,9 +227,10 @@ class CommandLine(object):
         else:
             self.args = self.parser.parse_args(input_options)
 
-        if self.args is not None and self.args.debug:
-            print(self.args)
-            print(input_options)
+        if self.args is not None:
+            if self.args.debug:
+                print(self.args)
+                print(input_options)
 
             self.args.func()
 

--- a/outrigger/index/adjacencies.py
+++ b/outrigger/index/adjacencies.py
@@ -6,6 +6,7 @@ import warnings
 
 import gffutils
 from gffutils.helpers import merge_attributes
+import joblib
 
 from ..common import JUNCTION_ID, EXON_START, EXON_STOP, CHROM, STRAND
 from ..io.gtf import transform
@@ -196,13 +197,9 @@ class ExonJunctionAdjacencies(object):
             # double-counting exons
             progress('\tFinding all exons on chromosome {chrom} '
                      '...'.format(chrom=chrom))
-            # exon_locations = joblib.Parallel(n_jobs=self.n_jobs)(
-            #     joblib.delayed(_neighboring_exons)(junction, df, 'left')
-            #     for junction in df.region)
-            exon_locations = []
-            for junction in df.region:
-                exon_locations.append(_neighboring_exons(junction, df, 'left'))
-            exon_locations = pd.concat(exon_locations, ignore_index=True)
+            exon_locations = joblib.Parallel(n_jobs=self.n_jobs)(
+                joblib.delayed(_neighboring_exons)(junction, df, 'left')
+                for junction in df.region)
             done(n_tabs=3)
 
             progress('\tFiltering for only novel exons on chromosome {chrom} '


### PR DESCRIPTION
- Parallelize exon detection
- Turn off `--debug` bug where only with `--debug` bug did the outrigger sub-command actually run

## Release checklist

- [x] 1. Check that version numbers in `outrigger/outrigger/__init__.py` and `outrigger/setup.py` match
- [x] 2. Add release notes in `outrigger/docs/releases`
- [x] 3. Copy release notes to `outrigger/HISTORY.rst`
- [x] 4. Convert `README.md` to RST:

```
pandoc --from=markdown_github --to=rst README.md > README.rst
```

- [x] 5. Create an annotated tag for git and push it:

```
git tag -a v0.2.1 -m "v0.2.1 - Release *with* requirements.txt"
git push origin v0.2.1
```

- [ ] 6. (If you messed up) and made the tag too early and later made changes that should be added to the tag, remove the remote tag and force re-add the local tag:

```
git push origin :refs/tags/v0.2.1
git tag -fa v0.2.1
git push origin master --tags
```


- [x] 7. Do a test run of uploading to PyPI test:
```
python setup.py register -r pypitest
python setup.py sdist upload -r pypitest
```

- [ ] 8. (If there's an error) in either the `HISTORY.rst` or `README.rst` file, you will get an error. To narrow down this error, look for the corresponding line in `outrigger.egg-info`. It won't be exactly the same line because of the header but it will be closer since `PKG-INFO` concatenates your `README.rst` and `HISTORY.rst` files.

```
warning: unexpected indent on line 615 blah blah I'm pypi RST and I'm way too strict
```

- [x] 10. Check the [PyPI test server](https://testpypi.python.org/pypi) and make sure everything is there and the RST is rendered correctly.
- [ ] 11. Do a test installation in a `conda` environment using the PyPI test server

```
conda create --yes -n outrigger_pypi_test_v0.2.1 --file conda_requirements.txt
# Change to a different directory to make sure you're not importing the `outrigger` folder
cd $HOME
source activate outrigger_pypi_test_v0.2.1
pip install --index-url https://testpypi.python.org/pypi outrigger --extra-index-url https://pypi.python.org/simple
```

- [x] 12. Make sure that the correct `outrigger` from the right environment is getting referenced. `which outrigger` should have the following output:

```
$ which outrigger
/Users/olga/anaconda3/envs/outrigger_pypi_v0.2.1/bin/outrigger
```

- [x] 13. Check that the installation was successful. `outrigger -h` should have the following output:


    $ outrigger -h
    usage: outrigger [-h] {index,validate,psi} ...

    Calculate "percent-spliced in" (Psi) scores of alternative splicing on a *de
    novo*, custom-built splicing index

    positional arguments:
      {index,validate,psi}  Sub-commands
        index               Build an index of splicing events using a graph
                            database on your junction reads and an annotation
        validate            Ensure that the splicing events found all have the
                            correct splice sites
        psi                 Calculate "percent spliced-in" (Psi) values using the
                            splicing event index built with "outrigger index"

    optional arguments:
      -h, --help            show this help message and exit


- [x] 14. Upload to PyPI:

```
python setup.py register -r pypi
python setup.py sdist upload -r pypi
```

- [ ] 15. (Doesn't really work yet) Upload to Anaconda.org:

```
anaconda login
anaconda upload dist/*.tar.gz
```
