### PR TITLE
Running out of memory when finding events

### DIFF
--- a/outrigger/index/adjacencies.py
+++ b/outrigger/index/adjacencies.py
@@ -203,15 +203,15 @@ class ExonJunctionAdjacencies(object):
                 for junction in df.region))
             done(n_tabs=3)
 
-            progress('\t\tFiltering for only novel exons on chromosome {chrom} '
-                     '...'.format(chrom=chrom))
+            progress('\t\tFiltering for only novel exons on chromosome {chrom}'
+                     ' ...'.format(chrom=chrom))
             novel_exons = set(x for x in exon_locations if
                               'exon:{}:{}-{}:{}'.format(*x)
                               not in self.existing_exons)
             done(n_tabs=4)
 
-            progress('\t\tCreating gffutils.Feature objects for each novel exon,'
-                     ' plus potentially its overlapping gene')
+            progress('\t\tCreating gffutils.Feature objects for each novel '
+                     'exon, plus potentially its overlapping gene')
             exon_features = [self.exon_location_to_feature(*x)
                              for x in novel_exons]
             done(n_tabs=4)

--- a/outrigger/index/adjacencies.py
+++ b/outrigger/index/adjacencies.py
@@ -225,6 +225,7 @@ class ExonJunctionAdjacencies(object):
                                id_spec={'novel_exon': 'location_id'},
                                transform=transform)
             except ValueError:
+                progress('\tNo novel exons found on chromosome '
                          '{chrom}'.format(chrom=chrom))
             done(n_tabs=4)
 

--- a/outrigger/io/gtf.py
+++ b/outrigger/io/gtf.py
@@ -9,7 +9,7 @@ import os
 import gffutils
 import pandas as pd
 
-from ..common import STRAND, SPLICE_TYPE_ISOFORM_EXONS
+from ..common import SPLICE_TYPE_ISOFORM_EXONS
 from ..region import Region
 
 # Annotations from:
@@ -127,7 +127,8 @@ class SplicingAnnotator(object):
         Parameters
         ----------
         exons : list
-            List of exon ids, e.g. ["exon:chr1:100-200:+", "exon:chr1:300-400:+"]
+            List of exon ids, e.g. ["exon:chr1:100-200:+",
+            "exon:chr1:300-400:+"]
 
         Returns
         -------
@@ -136,7 +137,8 @@ class SplicingAnnotator(object):
         """
         regions = tuple(map(Region, exons))
 
-        lengths = dict(('exon{}'.format(i+1), len(exon)) for i, exon in enumerate(regions))
+        lengths = dict(('exon{}'.format(i+1), len(exon))
+                       for i, exon in enumerate(regions))
         strand = regions[0].strand
 
         first_exon = regions[0]

--- a/outrigger/tests/index/test_events.py
+++ b/outrigger/tests/index/test_events.py
@@ -167,7 +167,7 @@ def assert_graph_items_equal(graph1, items1, graph2, items2):
             test.sort()
             true.sort()
 
-            pdt.assert_numpy_array_equal(test, true)
+            pdt.assert_equal(test, true)
 
     for number2, item2 in enumerate(items2):
         for direction in DIRECTIONS:
@@ -181,7 +181,7 @@ def assert_graph_items_equal(graph1, items1, graph2, items2):
             test.sort()
             true.sort()
 
-            pdt.assert_numpy_array_equal(test, true)
+            pdt.assert_equal(test, true)
 
 
 class TestEventMaker(object):
@@ -199,11 +199,11 @@ class TestEventMaker(object):
         pdt.assert_frame_equal(test.junction_exon_triples,
                                junction_exon_triples)
         assert test.db is None
-        exons = junction_exon_triples.exon.unique()
-        junctions = junction_exon_triples.junction.unique()
+        exons = tuple(junction_exon_triples.exon.unique())
+        junctions = tuple(junction_exon_triples.junction.unique())
 
-        pdt.assert_numpy_array_equal(test.exons, exons)
-        pdt.assert_numpy_array_equal(test.junctions, junctions)
+        pdt.assert_equal(test.exons, exons)
+        pdt.assert_equal(test.junctions, junctions)
         pdt.assert_equal(sorted(test.items), sorted(items))
 
         assert_graph_items_equal(test.graph, test.items, graph, items)


### PR DESCRIPTION
Get lengths when you get the exon attributes to avoid doing a gigantic database merge and running out of memory (as I am now)