### PR TITLE
Incompatible chroms between fasta and annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ You'll want to add the [`bioconda`](https://bioconda.github.io/) channel to make
 ```
 conda config --add channels r
 conda config --add channels bioconda
-
 ```
 
 Create an environment called `outrigger-env`. Python 2.7, Python 3.4, and Python 3.5 are supported.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Outrigger is a program which uses junction reads from RNA seq data, and a graph database to create a *de novo* alternative splicing annotation with a graph database, and quantify percent spliced-in (Psi) of the events.
 
-* Free software: BSD license
+* Free and open source software: BSD license
 
 ## Features
 

--- a/docs/releases/v0.2.9.rst
+++ b/docs/releases/v0.2.9.rst
@@ -1,0 +1,25 @@
+v0.2.9 (...)
+------------
+
+
+
+New features
+~~~~~~~~~~~~
+
+Plotting functions
+~~~~~~~~~~~~~~~~~~
+
+API changes
+~~~~~~~~~~~
+
+
+Bug fixes
+~~~~~~~~~
+
+- Fixed an issue in ``outrigger validate`` when fasta file and genome
+  annotation didn't have overlapping chromosomes and ``outrigger validate``
+  would simply fail rather than gracefully skipping those events.
+
+Miscellaneous
+~~~~~~~~~~~~~
+

--- a/outrigger/__init__.py
+++ b/outrigger/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = 'Olga Botvinnik'
 __email__ = 'olga.botvinnik@gmail.com'
-__version__ = '0.2.8dev'
+__version__ = '0.2.9dev'
 
 __all__ = ['psi', 'region', 'util', 'io', 'validate', 'index',
            'common']

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ test_requirements = [
 
 setup(
     name='outrigger',
-    version='0.2.8dev',
+    version='0.2.9dev',
     description="Outrigger is a tool to de novo annotate splice sites "
                 "and exons",
     long_description=readme + '\n\n' + history,


### PR DESCRIPTION
If a chromosome was in the GTF annotation file but not in the genome `fasta` file, then `outrigger validate` would fail with the following error:

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-19-73c99f62ab80> in <module>()
----> 1 check_splice_sites.read_splice_sites(bed, genome, fasta)

/home/obotvinnik/workspace-git/outrigger/outrigger/validate/check_splice_sites.pyc in read_splice_sites(bed, genome, fasta, direction)
     61         records = SeqIO.parse(f, 'fasta')
     62         records = pd.Series([str(r.seq) for r in records],
---> 63                             index=[b.name for b in bed])
     64     # import pdb; pdb.set_trace()
     65     return records

/home/obotvinnik/anaconda/envs/outrigger/lib/python2.7/site-packages/pandas/core/series.pyc in __init__(self, data, index, dtype, name, copy, fastpath)
    241                                        raise_cast_failure=True)
    242 
--> 243                 data = SingleBlockManager(data, index, fastpath=True)
    244 
    245         generic.NDFrame.__init__(self, data, fastpath=True)

/home/obotvinnik/anaconda/envs/outrigger/lib/python2.7/site-packages/pandas/core/internals.pyc in __init__(self, block, axis, do_integrity_check, fastpath)
   4045         if not isinstance(block, Block):
   4046             block = make_block(block, placement=slice(0, len(axis)), ndim=1,
-> 4047                                fastpath=True)
   4048 
   4049         self.blocks = [block]

/home/obotvinnik/anaconda/envs/outrigger/lib/python2.7/site-packages/pandas/core/internals.pyc in make_block(values, placement, klass, ndim, dtype, fastpath)
   2662                      placement=placement, dtype=dtype)
   2663 
-> 2664     return klass(values, ndim=ndim, fastpath=fastpath, placement=placement)
   2665 
   2666 # TODO: flexible with index=None and/or items=None

/home/obotvinnik/anaconda/envs/outrigger/lib/python2.7/site-packages/pandas/core/internals.pyc in __init__(self, values, ndim, fastpath, placement, **kwargs)
   1794 
   1795         super(ObjectBlock, self).__init__(values, ndim=ndim, fastpath=fastpath,
-> 1796                                           placement=placement, **kwargs)
   1797 
   1798     @property

/home/obotvinnik/anaconda/envs/outrigger/lib/python2.7/site-packages/pandas/core/internals.pyc in __init__(self, values, placement, ndim, fastpath)
    108             raise ValueError('Wrong number of items passed %d, placement '
    109                              'implies %d' % (len(self.values),
--> 110                                              len(self.mgr_locs)))
    111 
    112     @property

ValueError: Wrong number of items passed 153907, placement implies 153920
```

This is a result of the number of actual sequences calculated to be fewer than the number of events going in, so now only the found sequences are reported