### PR TITLE
Add issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+Hi! Thanks for using Outrigger.
+
+If you are reporting an issue or a feature request:
+
+- Please use the [GitHub issue](https://github.com/yeolab/outrigger/issues)
+  search feature to check if your issue has been asked already. If it has,
+  please add your comments to the existing issue.
+
+- Where applicable, please fill out the details below to help us troubleshoot
+  the issue that you are facing. Please be as thorough as you are able to
+  provide details on the issue.
+
+### Description
+
+[Description of the bug or feature]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expected to happen]
+
+**Actual behavior:** [What actually happened]
+
+### Versions
+
+You can get this information from executing `outrigger --version` at the
+command line. Please include the OS (Operating System) and what version of
+the OS you're running.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+[Briefly describe the problem this PR is attempting to address. Please use
+@mentions or reference issue numbers if that will help. Provide a list of
+top-level changes if possible.]
+
+Before you submit a pull request, check that it meets these guidelines:
+
+- [ ] The pull request should include tests.
+- [ ] If the pull request adds functionality, the docs should be updated. Put
+      your new functionality into a function with a docstring, and add the
+      feature to the list in README.md and README.rst.
+- [ ] The pull request should work for Python 2.7, 3.4, and 3.5.
+
+Fixes #[issue-number-here].


### PR DESCRIPTION
- Add simple issue template
- Add pr template
- Place both in `.github` directory to avoid cluttering root directory of project.

Closes #53 