### PR TITLE
Add conda environment for dev

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,5 +19,6 @@ dependencies:
 - sphinx_rtd_theme
 - pip:
     - graphlite
+    - pyflakes
     - recommonmark==0.4.0
     - nbsphinx

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,22 @@
+name: outrigger-env
+channels:
+  - conda-forge
+  - r
+  - bioconda
+dependencies:
+- python=3
+- pytest
+- pandas>=0.17.0
+- flake8
+- coverage
+- gffutils
+- pybedtools
+- biopython
+- bedtools
+- joblib
+- pysam
+- sphinx>=1.3.6
+- sphinx_rtd_theme
+- pip:
+    - graphlite
+    - recommonmark==0.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -20,3 +20,4 @@ dependencies:
 - pip:
     - graphlite
     - recommonmark==0.4.0
+    - nbsphinx

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
 - python=3
 - pytest
 - pandas>=0.17.0
-- flake8
 - coverage
 - gffutils
 - pybedtools
@@ -19,6 +18,5 @@ dependencies:
 - sphinx_rtd_theme
 - pip:
     - graphlite
-    - pyflakes
     - recommonmark==0.4.0
     - nbsphinx


### PR DESCRIPTION
This PR adds an `environment.yml` file that installs a development environment (including conda and pip packages).

The environment channels used will be searched in the following order: conda-forge, r, bioconda. We tend to use [conda-forge](https://conda-forge.github.io) packages over Continuum's anaconda packages as they are more up to date where Continuum lags due to their release cycle. [Aside: you may wish to upload outrigger to conda-forge at some point.]

This includes dependencies for building docs (sphinx, theme, recommonmark - markdown support, nbsphinx - notebook support).

To use this environment:

```bash
conda env create -f environment.yml
source activate outrigger-env
pip install .
```

To check if installed: ``outrigger -h``