### PR TITLE
Flake8 weirdness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,11 @@ before_script:
 
 script:
 - make coverage
-- make lint
 - make arabdopsis
+- conda create -n lint-env --yes flake8
+- source activate lint-env
+- make lint
+- deactivate lint-env
 
 after_success:
   - which -a curl

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -5,6 +5,6 @@ coverage
 gffutils
 pybedtools
 biopython
-bedtools
 joblib
 pysam
+bedtools

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,6 +1,5 @@
 pytest
 pandas>=0.17.0
-flake8
 coverage
 gffutils
 pybedtools

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,9 @@ pytest
 pandas>=0.17.0
 flake8
 coverage
-graphlite
 gffutils>=0.8.7.1
 pybedtools
 biopython
 joblib
 pysam
-pyflakes
+graphlite

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pytest
 pandas>=0.17.0
-flake8
 coverage
 gffutils>=0.8.7.1
 pybedtools


### PR DESCRIPTION
The build is failing now due to issues with `flake8`, and the current v0.2.9 version can't be built on the [bioconda recipes](https://github.com/bioconda/bioconda-recipes/pull/2941) because `flake8` installs through setuptools, which is not allowed. This PR proposes to remove `flake8` from dependencies and make a separate lint testing environment for travis.

Before you submit a pull request, check that it meets these guidelines:

- [x] The pull request should include tests.
- [x] If the pull request adds functionality, the docs should be updated. Put
      your new functionality into a function with a docstring, and add the
      feature to the list in README.md and README.rst.
- [x] The pull request should work for Python 2.7, 3.4, and 3.5.
