### PR TITLE
Low memory

### DIFF
--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -1,0 +1,25 @@
+v1.0.0 (...)
+------------
+
+This is the first major release of ``outrigger``!!!
+
+New features
+~~~~~~~~~~~~
+
+- Parallelized event across chromosomes
+- Added ``--low-memory`` flag for ``index``, ``validate``, and ``psi`` commands
+  to use a smaller memory footprint when reading CSV files.
+
+Plotting functions
+~~~~~~~~~~~~~~~~~~
+
+API changes
+~~~~~~~~~~~
+
+
+Bug fixes
+~~~~~~~~~
+
+Miscellaneous
+~~~~~~~~~~~~~
+

--- a/outrigger/__init__.py
+++ b/outrigger/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = 'Olga Botvinnik'
 __email__ = 'olga.botvinnik@gmail.com'
-__version__ = '0.3.0dev'
+__version__ = '1.0.0dev'
 
 __all__ = ['psi', 'region', 'util', 'io', 'validate', 'index',
            'common']

--- a/outrigger/commandline.py
+++ b/outrigger/commandline.py
@@ -439,7 +439,8 @@ class Subcommand(object):
         else:
             util.progress('Found compiled junction reads file in {} and '
                           'reading it in ...'.format(self.junction_reads))
-            splice_junctions = pd.read_csv(self.junction_reads)
+            splice_junctions = pd.read_csv(self.junction_reads,
+                                           **common.READ_CSV_KWS)
             util.done()
         splice_junctions = self.filter_junctions_on_reads(splice_junctions)
 
@@ -599,7 +600,7 @@ class Index(Subcommand):
             junction_exon_triples.to_csv(csv, index=False)
             util.done()
         elif self.resume:
-            junction_exon_triples = pd.read_csv(csv)
+            junction_exon_triples = pd.read_csv(csv, **common.READ_CSV_KWS)
         else:
             raise ValueError("Found existing junction-exon-triples file "
                              "({csv}) but don't "
@@ -879,7 +880,7 @@ class Psi(SubcommandAfterIndex):
                 'Reading splice junction reads from {} ...'.format(
                     self.junction_reads))
             junction_reads = pd.read_csv(
-                self.junction_reads, dtype=dtype)
+                self.junction_reads, dtype=dtype, **common.READ_CSV_KWS)
             util.done()
         except OSError:
             raise IOError(
@@ -934,7 +935,8 @@ class Psi(SubcommandAfterIndex):
                           ' ...'.format(name=splice_name, abbrev=splice_abbrev,
                                         filename=filename))
 
-            event_annotation = pd.read_csv(filename, index_col=0)
+            event_annotation = pd.read_csv(filename, index_col=0,
+                                           **common.READ_CSV_KWS)
             util.done()
 
             isoform_junctions = outrigger.common.ISOFORM_JUNCTIONS[

--- a/outrigger/commandline.py
+++ b/outrigger/commandline.py
@@ -137,6 +137,11 @@ class CommandLine(object):
                                        'reading. Default is -1, which means '
                                        'to use as many threads as are '
                                        'available.')
+        index_parser.add_argument('--low-memory', required=False,
+                                  default=False,
+                                  action='store_true',
+                                  help='If set, then use a smaller memory '
+                                       'footprint. By default, this is off.')
         overwrite_parser = index_parser.add_mutually_exclusive_group(
             required=False)
         overwrite_parser.add_argument('--force', action='store_true',
@@ -208,6 +213,11 @@ class CommandLine(object):
                                      action='store_true',
                                      help='If given, print debugging logging '
                                           'information to standard out')
+        validate_parser.add_argument('--low-memory', required=False,
+                                     default=False, action='store_true',
+                                     help='If set, then use a smaller memory '
+                                          'footprint. By default, this is '
+                                          'off.')
         validate_parser.set_defaults(func=self.validate)
 
         # --- Subcommand to calculate psi on the built index --- #
@@ -291,6 +301,11 @@ class CommandLine(object):
                                      'reading. Default is -1, which means '
                                      'to use as many threads as are '
                                      'available.')
+        psi_parser.add_argument('--low-memory', required=False,
+                                default=False,
+                                action='store_true',
+                                help='If set, then use a smaller memory '
+                                     'footprint. By default, this is off.')
         psi_parser.set_defaults(func=self.psi)
 
         if input_options is None or len(input_options) == 0:
@@ -440,7 +455,7 @@ class Subcommand(object):
             util.progress('Found compiled junction reads file in {} and '
                           'reading it in ...'.format(self.junction_reads))
             splice_junctions = pd.read_csv(self.junction_reads,
-                                           **common.READ_CSV_KWS)
+                                           low_memory=self.low_memory)
             util.done()
         splice_junctions = self.filter_junctions_on_reads(splice_junctions)
 
@@ -600,7 +615,8 @@ class Index(Subcommand):
             junction_exon_triples.to_csv(csv, index=False)
             util.done()
         elif self.resume:
-            junction_exon_triples = pd.read_csv(csv, **common.READ_CSV_KWS)
+            junction_exon_triples = pd.read_csv(csv,
+                                                low_memory=self.low_memory)
         else:
             raise ValueError("Found existing junction-exon-triples file "
                              "({csv}) but don't "
@@ -880,7 +896,7 @@ class Psi(SubcommandAfterIndex):
                 'Reading splice junction reads from {} ...'.format(
                     self.junction_reads))
             junction_reads = pd.read_csv(
-                self.junction_reads, dtype=dtype, **common.READ_CSV_KWS)
+                self.junction_reads, dtype=dtype, low_memory=self.low_memory)
             util.done()
         except OSError:
             raise IOError(
@@ -936,7 +952,7 @@ class Psi(SubcommandAfterIndex):
                                         filename=filename))
 
             event_annotation = pd.read_csv(filename, index_col=0,
-                                           **common.READ_CSV_KWS)
+                                           low_memory=self.low_memory)
             util.done()
 
             isoform_junctions = outrigger.common.ISOFORM_JUNCTIONS[

--- a/outrigger/common.py
+++ b/outrigger/common.py
@@ -57,3 +57,5 @@ ORDER_BY = ('seqid', 'start', 'end', 'frame', 'source', 'strand', 'attributes')
 UNIQUE_READS = 'unique_junction_reads'
 MULTIMAP_READS = 'multimap_junction_reads'
 MAX_OVERHANG = 'max_overhang'
+
+READ_CSV_KWS = dict(low_memory=False)

--- a/outrigger/common.py
+++ b/outrigger/common.py
@@ -57,5 +57,3 @@ ORDER_BY = ('seqid', 'start', 'end', 'frame', 'source', 'strand', 'attributes')
 UNIQUE_READS = 'unique_junction_reads'
 MULTIMAP_READS = 'multimap_junction_reads'
 MAX_OVERHANG = 'max_overhang'
-
-READ_CSV_KWS = dict(low_memory=False)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ test_requirements = [
 
 setup(
     name='outrigger',
-    version='0.3.0dev',
+    version='1.0.0dev',
     description="Outrigger is a tool to de novo annotate splice sites "
                 "and exons",
     long_description=readme + '\n\n' + history,


### PR DESCRIPTION
In running `outrigger psi` or other command line programs, I get these errors:

```
/home/obotvinnik/workspace-git/outrigger/outrigger/commandline.py:937: DtypeWarning: Columns (18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,42,43,44,45,46,47,48,49,50,51) have mixed types. Specify dtype option on import or set low_memory=False.
  cl = CommandLine(sys.argv[1:])
```

Since I expect most users of `outrigger` to use it on a large dataset, on a supercomputer, this PR sets `low_memory=False` by default, but can be turned off with the command line flag `--low-memory`

- [x] The pull request should include tests.
- [x] If the pull request adds functionality, the docs should be updated. Put
      your new functionality into a function with a docstring, and add the
      feature to the list in README.md and README.rst.
- [x] The pull request should work for Python 2.7, 3.4, and 3.5.
