### PR TITLE
Distinguish last_read_pos == 0 and last_read_pos is None

### DIFF
--- a/outrigger/io/bam.py
+++ b/outrigger/io/bam.py
@@ -17,7 +17,7 @@ def _report_read_positions(read, counter):
 
     last_read_pos = False
     for read_loc, genome_loc in read.get_aligned_pairs():
-        if read_loc is None and last_read_pos:
+        if read_loc is None and last_read_pos is not None:
             # Add one to be compatible with STAR output and show the
             # start of the intron (not the end of the exon)
             start = genome_loc + 1

--- a/outrigger/io/bam.py
+++ b/outrigger/io/bam.py
@@ -15,7 +15,7 @@ def _report_read_positions(read, counter):
     chrom = read.reference_name
     strand = '-' if read.is_reverse else '+'
 
-    last_read_pos = False
+    last_read_pos = None
     for read_loc, genome_loc in read.get_aligned_pairs():
         if read_loc is None and last_read_pos is not None:
             # Add one to be compatible with STAR output and show the


### PR DESCRIPTION
Hi,

I really like the project, it's very unfortunate that it's not maintained anymore.

In the `_report_read_positions(read, counter)` function in io.bam.py, if the the following loop:

```py
    last_read_pos = False
    for read_loc, genome_loc in read.get_aligned_pairs():
        ...
```

proceeds with the following sequence:

```
read_loc:               0 genome_loc:        15283628 last_read_pos:           False
read_loc:            None genome_loc:        15283629 last_read_pos:               0
read_loc:            None genome_loc:        15283630 last_read_pos:            None
read_loc:            None genome_loc:        15283631 last_read_pos:            None

...

read_loc:            None genome_loc:        15284476 last_read_pos:            None
read_loc:               1 genome_loc:        15284477 last_read_pos:            None
```

`if read_loc is None and last_read_pos:` condition cannot distinguish whether last_read_pos is 0 or None and this leads to the `UnboundLocalError: local variable 'start' referenced before assignment` exception.

This PR fixes that.

Fixes #83 