### PR TITLE
Pinning python version fixes bug

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - r
   - bioconda
 dependencies:
-- python=3
+- python=3.6.7
 - pytest
 - pandas>=0.17.0
 - coverage
@@ -16,6 +16,7 @@ dependencies:
 - pysam
 - sphinx>=1.3.6
 - sphinx_rtd_theme
+- outrigger
 - pip:
     - graphlite
     - recommonmark==0.4.0


### PR DESCRIPTION
When building the conda environment for outrigger, a newer version of Python is installed, which leads to the following error, as reported in #104:
`AttributeError: 'Series' object has no attribute 'iteritems'`

The error was resolved by pinning python to version 3.6.7. I also added outrigger directly in the `environment.yml` file. With this change, I could install `outrigger` using `mamba` and run without issues.

Fixes #104
